### PR TITLE
name threads

### DIFF
--- a/src/prefetch_reader.rs
+++ b/src/prefetch_reader.rs
@@ -27,35 +27,38 @@ impl PrefetchReader {
     }
 
     pub fn start_reader(mut self, tx: SyncSender<Vec<u8>>) -> JoinHandle<()> {
-        thread::spawn(move || {
-            while self.processed_len != self.file_len {
-                let remaining = self.file_len - self.processed_len;
-                let next_size = if remaining > self.read_size {
-                    self.read_size
-                } else {
-                    remaining
-                };
-                let mut extra_buffer = vec![0; next_size];
-                self.reader
-                    .read_exact(&mut extra_buffer)
-                    .unwrap_or_else(|e| {
-                        panic!(
-                            "Fail to read buffer for incomplete input:\n
+        thread::Builder::new()
+            .name("hprof-prefetch".to_string())
+            .spawn(move || {
+                while self.processed_len != self.file_len {
+                    let remaining = self.file_len - self.processed_len;
+                    let next_size = if remaining > self.read_size {
+                        self.read_size
+                    } else {
+                        remaining
+                    };
+                    let mut extra_buffer = vec![0; next_size];
+                    self.reader
+                        .read_exact(&mut extra_buffer)
+                        .unwrap_or_else(|e| {
+                            panic!(
+                                "Fail to read buffer for incomplete input:\n
                                 error->{}\n
                                 next->{}\n
                                 processed->{}\n
                                 file_len->{}\n
                                 remaining->{}",
-                            e,
-                            next_size,
-                            self.processed_len,
-                            self.file_len,
-                            self.file_len - self.processed_len
-                        )
-                    });
-                tx.send(extra_buffer).expect("Channel should not be closed");
-                self.processed_len += next_size
-            }
-        })
+                                e,
+                                next_size,
+                                self.processed_len,
+                                self.file_len,
+                                self.file_len - self.processed_len
+                            )
+                        });
+                    tx.send(extra_buffer).expect("Channel should not be closed");
+                    self.processed_len += next_size
+                }
+            })
+            .unwrap()
     }
 }


### PR DESCRIPTION
This PR gives proper names to the threads.

Bonus point, it shows up in `htop`

![names](https://user-images.githubusercontent.com/606963/146254941-bae9e368-dfc3-4a5d-8df4-494a97fc5a78.png)
